### PR TITLE
adds std::forward header file

### DIFF
--- a/wink/signal.hpp
+++ b/wink/signal.hpp
@@ -29,6 +29,7 @@
 #ifndef WINK_SIGNAL_HPP
 #define WINK_SIGNAL_HPP
 
+#include <algorithm>
 #include <vector>
 #include <utility>
 


### PR DESCRIPTION
I get the following on Android using gnustl_static and clang: error: 'find' is not a member of 'std'
http://www.cplusplus.com/reference/algorithm/find/