### PR TITLE
adds std::forward header file

### DIFF
--- a/wink/slot.hpp
+++ b/wink/slot.hpp
@@ -29,6 +29,7 @@
 #ifndef WINK_SLOT_HPP
 #define WINK_SLOT_HPP
 
+#include <algorithm>
 #include <utility>
 
 #include <wink/detail/FastDelegate.h>


### PR DESCRIPTION
I get the following on Android using gnustl_static and clang: error: 'find' is not a member of 'std'
http://www.cplusplus.com/reference/algorithm/find/