### PR TITLE
adds std::forward header file

### DIFF
--- a/wink/event_queue.hpp
+++ b/wink/event_queue.hpp
@@ -27,6 +27,7 @@
 #ifndef WINK_EVENT_QUEUE_HPP
 #define WINK_EVENT_QUEUE_HPP
 
+#include <algorithm>
 #include <queue>
 
 #include <wink/signal.hpp>


### PR DESCRIPTION
I get the following on Android using gnustl_static and clang: error: 'find' is not a member of 'std'
http://www.cplusplus.com/reference/algorithm/find/