### PR TITLE
Return the value when calling a slot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wink Signals
 
-A fast template signal library, for C++, using the [Fastest Possible C++ Delegates](http://www.codeproject.com/Articles/7150/Member-Function-Pointers-and-the-Fastest-Possible). This library is designed to be fast and easy to use. It is incredibly lightweight and type-safe. This library uses some C++11 features, so it may or may not compile with your compiler. Since it is designed to be easy-to-use, it is quite similar to the famous [boost::signals](http://www.boost.org/doc/libs/1_53_0/doc/html/signals.html) library, but it has it's differences here and there.
+A fast template signal library, for C++, using the [Fastest Possible C++ Delegates](http://www.codeproject.com/Articles/7150/Member-Function-Pointers-and-the-Fastest-Possible). This library is designed to be fast and easy to use. It is incredibly lightweight and type-safe. This library uses some C++11 and C++14 features, so it may or may not compile with your compiler. Since it is designed to be easy-to-use, it is quite similar to the famous [boost::signals](http://www.boost.org/doc/libs/1_53_0/doc/html/signals.html) library, but it has it's differences here and there.
 
 Please read the tutorial further down if you wish to use the library.
 

--- a/wink/slot.hpp
+++ b/wink/slot.hpp
@@ -91,9 +91,9 @@ namespace wink
 		/// Calls the slot
 		/// \param args Any arguments you want to pass to the slot
 		template <class ...Args>
-		void operator()(Args&&... args) const
+		auto operator()(Args&&... args) const
 		{
-			_delegate(std::forward<Args>(args)...);
+			return _delegate(std::forward<Args>(args)...);
 		}
 		
 		

--- a/wink/slot.hpp
+++ b/wink/slot.hpp
@@ -97,7 +97,7 @@ namespace wink
 		}
 		
 		
-		// comparision operators for sorting and comparing
+		// comparison operators for sorting and comparing
 		
 		bool operator==(const this_type& slot) const
 		{ return _delegate == slot._delegate; }


### PR DESCRIPTION
Auto return types require C++14 though, hence, I edited the readme.
I'm not sure if the compiler it was tested on still works though, but using MSVC++ 14.0, it compiles without any problems.