### PR TITLE
Disabled erase() on end-iterator

### DIFF
--- a/wink/signal.hpp
+++ b/wink/signal.hpp
@@ -67,7 +67,12 @@ namespace wink
 		template <typename... Args>
 		void disconnect(Args&&... args)
 		{
-			_slots.erase(std::find(_slots.begin(), _slots.end(), slot_type(std::forward<Args>(args)...)));
+			typename slot_array::const_iterator it = std::find(_slots.begin(), _slots.end(), slot_type(std::forward<Args>(args)...));
+			
+			if (it != _slots.end())
+			{
+				_slots.erase(it);
+			}
 		}
 		
 		/// Emits the events you wish to send to the call-backs

--- a/wink/signal.hpp
+++ b/wink/signal.hpp
@@ -67,8 +67,8 @@ namespace wink
 		template <typename... Args>
 		void disconnect(Args&&... args)
 		{
-			typename slot_array::const_iterator it = std::find(_slots.begin(), _slots.end(), slot_type(std::forward<Args>(args)...));
-			
+			auto it = std::find(_slots.begin(), _slots.end(), slot_type(std::forward<Args>(args)...));
+
 			if (it != _slots.end())
 			{
 				_slots.erase(it);


### PR DESCRIPTION
Calling disconnect() on a slot that could not be found lead to deleting end-iterator from the vector which is forbidden since only valid and dereferencable iterators can be erased.