### PR TITLE
Use captured lambdas as slots. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ sender.connect(&doSomething);
 
 // disconnect
 sender.disconnect(&doSomething);
+
+int x = 0;
+
+sender.connect_lambda([&]() { std::cout << x << std::endl; });
+
 ```
 
 #### 3. Emitting the slots in your signal

--- a/examples/Benchmark.cpp
+++ b/examples/Benchmark.cpp
@@ -65,8 +65,12 @@ struct EventHandler
 		// simple computation
 		int z = std::sqrt(y) * y + x;
 	}
-	
-	
+
+	void operator()(int x)
+	{
+		handleEvent(x);
+	}
+
 	/// Different function for a queue, since it uses a different prototype,
 	/// but it does contain the same implemenation
 	void queueHandleEvent(const int& x)
@@ -184,9 +188,45 @@ int main(int argc, char* argv[])
 		printTimeTaken(start, end);
 #endif // DO_PROPER_BENCHMARK
 	}
-	
-	
-	
+
+	{
+		typedef wink::signal<wink::slot<void(int)> > signal;
+		signal sender;
+		EventHandler handler;
+
+		std::shared_ptr<void> handle;
+		{
+				sender.connect_lambda([&](int x)
+				{
+					handler.handleEvent(x);
+				});
+		}
+
+		std::cout << "Using signal<slot<void(int)>> with captured lambda slot to handle events:\n";
+
+		#ifdef DO_PROPER_BENCHMARK
+		start = GetTimeNow();
+		#endif // DO_PROPER_BENCHMARK
+
+		for (int i = 0; i < AMOUNT_OF_TIMES_TO_SEND_EVENT; ++i)
+		{
+			for (std::vector<int>::iterator i = numbersToSend.begin(); i != numbersToSend.end(); ++i)
+			{
+				// emit the event
+				sender(*i);
+			}
+		}
+
+#ifdef DO_PROPER_BENCHMARK
+		end = GetTimeNow();
+
+		// print the time taken
+		printTimeTaken(start, end);
+#endif // DO_PROPER_BENCHMARK
+	}
+
+
+
 	{
 		EventHandler handler;
 		typedef wink::event_queue<int> event_queue;

--- a/wink/signal.hpp
+++ b/wink/signal.hpp
@@ -91,7 +91,7 @@ namespace wink
 		}
 
 		/// Disconnects a lambda slot to the signal.
-		///\param lambda. anytype which overloads operator()
+		///\param handle.  
 
 		void disconnect(std::shared_ptr<void> handle)
 		{

--- a/wink/slot.hpp
+++ b/wink/slot.hpp
@@ -70,7 +70,14 @@ namespace wink
 		slot(T* obj, MemFnPtr fn)
 			: _delegate(obj, fn)
 		{}
-		
+
+		/// Construct a slot with a overloaded operator() member function
+		/// \param obj The object that the overloaded operator() belongs to
+		template <typename T>
+		slot(T* obj)
+			: _delegate(obj, &T::operator())
+		{}
+
 		/// Copy constructor
 		slot(const this_type& slot)
 			: _delegate(slot._delegate)


### PR DESCRIPTION
Its really convenient to use captured lambdas and and objects with overloaded operator() as slots. This bit of code attempts that. 

Extra state added to manage lifetimes is needed to have a convenient syntax.  


